### PR TITLE
Move closed caption

### DIFF
--- a/H5P.BranchedVideo/branched-video.js
+++ b/H5P.BranchedVideo/branched-video.js
@@ -906,6 +906,14 @@ H5P.BranchedVideo = (function ($) {
         hideBar();
         seeker.addEventListener('mouseover', showBar, true);
         seeker.addEventListener('mouseout', hideBar, true);
+        // TODO
+        // handle closed caption moving up after entering full screen
+        var track = getBranch(currentVideoPlaying).getVideoHTML().textTracks[0];
+        if (track){
+          for (var x = 0; x < track.cues.length; x++){
+            track.cues[x].line = 1;
+          }
+        }
       });
 
       // Respond to exit full screen event
@@ -915,6 +923,14 @@ H5P.BranchedVideo = (function ($) {
         seeker.removeEventListener('mouseover', showBar, true);
         seeker.removeEventListener('mouseout', hideBar, true);
         showBar();
+        // TODO
+        // handle closed caption moving down after exit full screen
+        var track = getBranch(currentVideoPlaying).getVideoHTML().textTracks[0];
+        if (track){
+          for (var x = 0; x < track.cues.length; x++){
+            track.cues[x].line = 'auto';
+          }
+        }
       });
       fullScreenButton.onclick = function(){toggleFullScreen()};
       rightControls.appendChild(volumeDiv);

--- a/H5P.BranchedVideo/branched-video.js
+++ b/H5P.BranchedVideo/branched-video.js
@@ -244,14 +244,14 @@ H5P.BranchedVideo = (function ($) {
       }
 
       // FUNCTIONS FOR THE ACTUAL BRANCH
-      // hide video div
+      // hide and pause video div
       this.stopVideo = function(){
         var videoDiv = this.getVideoDivHTML();
         videoDiv.style.display = 'none';
         var video = this.getVideoHTML();
         video.pause();
       }
-      // show video div
+      // show and play video div
       this.playVideo = function(){
         var videoDiv = this.getVideoDivHTML();
         videoDiv.style.display = 'block';
@@ -265,6 +265,21 @@ H5P.BranchedVideo = (function ($) {
       // gets type of Videos
       this.getType = function(){
         return this.type;
+      }
+      // moves closed caption  if exists
+      // location(String): 'up', 'down'
+      this.moveClosedCaption = function(location){
+        var lineVal = 'auto';
+        if (location == 'up'){
+          lineVal = 1;
+          // sets the line value to 1 for the cues, which moves it up
+        }
+        var track = this.getVideoHTML().textTracks[0];
+        if (track){
+          for (var x = 0; x < track.cues.length; x++){
+            track.cues[x].line = lineVal;
+          }
+        }
       }
 
     } // end of branch
@@ -326,6 +341,7 @@ H5P.BranchedVideo = (function ($) {
 
 //  INITIALIZE
     self.helpMode = false;
+    self.closedCaption = false;
     var mainSlug = this.options.mainBranchSlug;
     var currentVideoPlaying = mainSlug;
 
@@ -359,10 +375,17 @@ H5P.BranchedVideo = (function ($) {
       nextVid.volume = currVid.volume;
 
       // handle closed caption
-      if( currVid.textTracks[0] != undefined && nextVid.textTracks[0] != undefined){
+      if(self.closedCaption){
         // TODO FINISH UP THIS functions
-        if (currVid.textTracks[0].mode = 'showing'){
+        if (currVid.textTracks[0]){
+          currVid.textTracks[0].mode = 'hidden';
+          getBranch(currentVideoPlaying).moveClosedCaption('down');
+        }
+        if (nextVid.textTracks[0]){
           nextVid.textTracks[0].mode = 'showing';
+          if (H5P.isFullscreen){
+            getBranch(goToSlug).moveClosedCaption('up');
+          }
         }
       }
 
@@ -795,6 +818,7 @@ H5P.BranchedVideo = (function ($) {
         }
       }
 
+      // just change color when hovering on button
       helpButton.onmouseenter = function(){
         helpButton.style.backgroundColor = '#3f89ff';
         helpButton.style.color = 'white';
@@ -822,15 +846,18 @@ H5P.BranchedVideo = (function ($) {
           console.log('no closed caption for this video');
           return ;
         }
-        if (tracks.mode == 'hidden'){
+        if (self.closedCaption == false){
           tracks.mode = 'showing';
           ccButton.innerHTML = 'Closed Caption &#10003';
+          self.closedCaption = true;
         } else {
           tracks.mode = 'hidden';
           ccButton.innerHTML = 'Closed Caption';
+          self.closedCaption = false;
         }
       }
 
+      // just change color on hover
       ccButton.onmouseenter = function(){
         ccButton.style.backgroundColor = '#3f89ff';
         ccButton.style.color = 'white';
@@ -853,7 +880,7 @@ H5P.BranchedVideo = (function ($) {
         }
       }
 
-      // removes div when we click anything else
+      // removes settings options when we click anything else
       window.onclick = function(event) {
         if (!event.target.matches('.tapestry-settings-button')) {
           settingsDiv.style.display = 'none';
@@ -908,13 +935,10 @@ H5P.BranchedVideo = (function ($) {
         seeker.addEventListener('mouseout', hideBar, true);
         // TODO
         // handle closed caption moving up after entering full screen
-        var track = getBranch(currentVideoPlaying).getVideoHTML().textTracks[0];
-        if (track){
-          for (var x = 0; x < track.cues.length; x++){
-            track.cues[x].line = 1;
-          }
-        }
+        getBranch(currentVideoPlaying).moveClosedCaption('up');
+
       });
+
 
       // Respond to exit full screen event
       self.on('exitFullScreen', function () {
@@ -925,12 +949,7 @@ H5P.BranchedVideo = (function ($) {
         showBar();
         // TODO
         // handle closed caption moving down after exit full screen
-        var track = getBranch(currentVideoPlaying).getVideoHTML().textTracks[0];
-        if (track){
-          for (var x = 0; x < track.cues.length; x++){
-            track.cues[x].line = 'auto';
-          }
-        }
+        getBranch(currentVideoPlaying).moveClosedCaption('down');
       });
       fullScreenButton.onclick = function(){toggleFullScreen()};
       rightControls.appendChild(volumeDiv);

--- a/H5P.BranchedVideo/branched-video.js
+++ b/H5P.BranchedVideo/branched-video.js
@@ -367,7 +367,6 @@ H5P.BranchedVideo = (function ($) {
 
       // handle closed caption
       if(self.closedCaption){
-        // TODO FINISH UP THIS functions
         if (currVid.textTracks[0]){
           currVid.textTracks[0].mode = 'hidden';
           getBranch(currentVideoPlaying).moveClosedCaption('down');
@@ -791,7 +790,6 @@ H5P.BranchedVideo = (function ($) {
       volumeDiv.appendChild(volumeSlider);
       volumeDiv.appendChild(volumeButton);
 
-      // TODO: update
       // SETTINGS
       var settingsButton = document.createElement('button');
       settingsButton.type = 'button';
@@ -949,10 +947,8 @@ H5P.BranchedVideo = (function ($) {
         hideBar();
         seeker.addEventListener('mouseover', showBar, true);
         seeker.addEventListener('mouseout', hideBar, true);
-        // TODO
         // handle closed caption moving up after entering full screen
         getBranch(currentVideoPlaying).moveClosedCaption('up');
-
       });
 
 
@@ -963,7 +959,6 @@ H5P.BranchedVideo = (function ($) {
         seeker.removeEventListener('mouseover', showBar, true);
         seeker.removeEventListener('mouseout', hideBar, true);
         showBar();
-        // TODO
         // handle closed caption moving down after exit full screen
         getBranch(currentVideoPlaying).moveClosedCaption('down');
       });

--- a/H5P.BranchedVideo/library.json
+++ b/H5P.BranchedVideo/library.json
@@ -3,7 +3,7 @@
   "description": "Creates a module of Branched Videos",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 579,
+  "patchVersion": 590,
   "runnable": 1,
   "author": "Amendor AS",
   "license": "cc-by-sa",

--- a/H5P.BranchedVideo/library.json
+++ b/H5P.BranchedVideo/library.json
@@ -3,7 +3,7 @@
   "description": "Creates a module of Branched Videos",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 551,
+  "patchVersion": 579,
   "runnable": 1,
   "author": "Amendor AS",
   "license": "cc-by-sa",


### PR DESCRIPTION
closed caption mode persists everytime you jump, regardless if the next one has CC or not. So if the first branch has CC, the second doesn't and the third does, the third CC will still show.

If full screen, the closed caption is moved up. If you do full screen jump, it will work. Every time you leave branch, it moves the CC back down. This is so that if you jump while full screen, and then return while not in full screen, the position of the CC will be in the correct bottom part of the video when you return.

fixes #9 .