### PR TITLE
UI tweaks 9-19

### DIFF
--- a/H5P.BranchedVideo/branched-video.css
+++ b/H5P.BranchedVideo/branched-video.css
@@ -238,14 +238,7 @@ button:focus {
   -webkit-appearance: none;
   height: 7px;
   z-index: 0;
-  background-image:
-    -webkit-gradient(
-            linear,
-            left top,
-            right top,
-            color-stop(0, #1BB1FF),
-            color-stop(0, #000000)
-        );
+  background: #000000
 }
 
 
@@ -259,14 +252,7 @@ button:focus {
   -webkit-appearance: none;
   height: 7px;
   z-index: 0;
-  background-image:
-    -webkit-gradient(
-            linear,
-            left top,
-            right top,
-            color-stop(0, #000000),
-            color-stop(0, #1BB1FF)
-        );
+  background: #1BB1FF;
 }
 
 .tapestry-branch-button{
@@ -312,6 +298,7 @@ button:focus {
   font-size: 8px;
   color: #FFFFFF;
   margin : 0;
+  min-width : 50px;
 }
 
 .tapestry-help-text{

--- a/H5P.BranchedVideo/branched-video.css
+++ b/H5P.BranchedVideo/branched-video.css
@@ -203,7 +203,7 @@ button:focus {
   height: 14px;
   width: 14px;
   cursor: pointer;
-  margin-top: 0px;
+  margin: -4px 0 -3px;
 }
 
 /* TODO: make cross-browser compatible */
@@ -237,6 +237,7 @@ button:focus {
 .tapestry-slanted-bar input[type='range']{
   -webkit-appearance: none;
   height: 7px;
+  z-index: 0;
   background-image:
     -webkit-gradient(
             linear,
@@ -257,6 +258,7 @@ button:focus {
 .tapestry-played-slanted-bar input[type='range']{
   -webkit-appearance: none;
   height: 7px;
+  z-index: 0;
   background-image:
     -webkit-gradient(
             linear,

--- a/H5P.BranchedVideo/branched-video.js
+++ b/H5P.BranchedVideo/branched-video.js
@@ -207,7 +207,7 @@ H5P.BranchedVideo = (function ($) {
           seconds = "0"+ seconds;
         }
         var timeText = document.createElement('p');
-        var text = document.createTextNode("0:00/" + mins + ':' + seconds);
+        var text = document.createTextNode("0:00 / " + mins + ':' + seconds);
         timeText.id = 'tapestry-time-text-' + this.slug;
         timeText.classList.add('tapestry-time-text');
         timeText.style.position = 'absolute';
@@ -523,7 +523,7 @@ H5P.BranchedVideo = (function ($) {
           }
           branchText.style.left = slantedDiff * 2 + 13 + 'px';
           var timeText = nextBranch.getTimeTextHTML();
-          timeText.style.left = 'calc( 103%  + ' + (slantedDiff*2 + 5*(tempLevel-1)) + 'px )';
+          timeText.style.left = 'calc( 103%  + ' + (slantedDiff*2 + 5*(tempLevel-1)) + 6 + 'px )';
           timeText.style.top = -3 + 'px';
 
           // recurse
@@ -625,7 +625,7 @@ H5P.BranchedVideo = (function ($) {
         }
         var textStart = minsStart + ':' + secondsStart;
         var time = branch.getTimeTextHTML();
-        time.innerHTML = textStart + '/' + textEnd;
+        time.innerHTML = textStart + ' / ' + textEnd;
 
         // removes return text
         var returnLink = document.getElementById('tapestry-link-return-' + slug);
@@ -634,7 +634,6 @@ H5P.BranchedVideo = (function ($) {
         }
       };
 
-      // CHANGED
       // video on click listener
       video.onclick = function(){
         if (!video.paused){
@@ -797,7 +796,6 @@ H5P.BranchedVideo = (function ($) {
           var mainSlider = currentBranch.getSliderDivHTML();
           mainSlider.classList.add('tapestry-selected-slider');
           mainSlider.childNodes[0].value = 0;
-          // CHANGED
           // removes play button for main video on ended
           currentBranch.getVideoHTML().onended = function(){
             var playButton = document.getElementsByClassName('tapestry-play-button')[0];
@@ -1224,7 +1222,7 @@ H5P.BranchedVideo = (function ($) {
       // HELP EVENTS: on mouseover
       // HELP play button
       playButton.onmouseover = function(){
-        var temp = getHelpText('tapestry-help-play-button', 'CLICK TO PLAY VIDEO' );
+        var temp = getHelpText('tapestry-help-play-button', 'Click to play video' );
         temp.style.left = '2%';
         temp.style.top = '60%';
         if (self.helpMode){
@@ -1232,12 +1230,12 @@ H5P.BranchedVideo = (function ($) {
         }
       }
       playButton.onmouseout = function(){
-        getHelpText('tapestry-help-play-button', 'CLICK TO PLAY VIDEO').style.display = 'none';
+        getHelpText('tapestry-help-play-button', '').style.display = 'none';
       }
 
       // HELP pause button
       pauseButton.onmouseover = function(){
-        var temp = getHelpText('tapestry-help-pause-button', 'CLICK TO PAUSE VIDEO' );
+        var temp = getHelpText('tapestry-help-pause-button', 'Click to pause video' );
         temp.style.left = '2%';
         temp.style.top = '60%';
         if (self.helpMode){
@@ -1245,12 +1243,12 @@ H5P.BranchedVideo = (function ($) {
         }
       }
       pauseButton.onmouseout = function(){
-        getHelpText('tapestry-help-pause-button', 'CLICK TO PAUSE VIDEO').style.display = 'none';
+        getHelpText('tapestry-help-pause-button', '').style.display = 'none';
       }
 
       // HELP volume button
       volumeButton.onmouseover = function(){
-        var temp = getHelpText('tapestry-help-volume-button', 'DRAG TO CHANGE VOLUME' );
+        var temp = getHelpText('tapestry-help-volume-button', 'Drag to change volume' );
         temp.style.left = '83%';
         temp.style.top = '60%';
         if (self.helpMode){
@@ -1263,7 +1261,7 @@ H5P.BranchedVideo = (function ($) {
 
       // HELP fullscreen
       fullScreenButton.onmouseover = function(){
-        var temp = getHelpText('tapestry-help-fullScreen-button', 'TOGGLE FULL SCREEN' );
+        var temp = getHelpText('tapestry-help-fullScreen-button', 'Toggle fullscreen' );
         temp.style.left = '87%';
         temp.style.top = '60%';
         if (self.helpMode){
@@ -1286,7 +1284,7 @@ H5P.BranchedVideo = (function ($) {
           if (self.isMobile){
             return;
           }
-          var temp = getHelpText('tapestry-help-'+ slug + '-slider', 'CLICK TO JUMP TO ' + slug );
+          var temp = getHelpText('tapestry-help-'+ slug + '-slider', 'Click to jump to ' + slug );
           var dom = $container.get(0);
           var rect = dom.getBoundingClientRect();
           var currBranch = getBranch(currentVideoPlaying);
@@ -1331,7 +1329,7 @@ H5P.BranchedVideo = (function ($) {
             time = '0:00';
           }
           if (self.helpMode){
-            var temp = getHelpText('tapestry-help-'+ slug + '-slider', 'CLICK TO JUMP TO ' + slug + ' at ' + time );
+            var temp = getHelpText('tapestry-help-'+ slug + '-slider', 'Click to jump to ' + slug + ' at ' + time );
           } else {
             var temp = getHelpText('tapestry-help-'+ slug + '-slider',  time );
           }

--- a/H5P.BranchedVideo/branched-video.js
+++ b/H5P.BranchedVideo/branched-video.js
@@ -540,7 +540,7 @@ H5P.BranchedVideo = (function ($) {
       var duration = branch.videoLength;
       var listOfCitations = branch.getCitationLinks();
 
-      //video listener
+      //video ontimeupdate listener
       video.ontimeupdate = function(){
         // updates slider value when video time changes
         var time = video.currentTime;
@@ -634,6 +634,24 @@ H5P.BranchedVideo = (function ($) {
         }
       };
 
+      // CHANGED
+      // video on click listener
+      video.onclick = function(){
+        if (!video.paused){
+          var playButton = document.getElementsByClassName('tapestry-play-button')[0];
+          playButton.style.display = 'block';
+          var pauseButton = document.getElementsByClassName('tapestry-pause-button')[0];
+          pauseButton.style.display = 'none';
+          video.pause();
+        } else {
+          var playButton = document.getElementsByClassName('tapestry-play-button')[0];
+          playButton.style.display = 'none';
+          var pauseButton = document.getElementsByClassName('tapestry-pause-button')[0];
+          pauseButton.style.display = 'block';
+          video.play();
+        }
+      }
+
       // slider listener
       // for non mobile slider listener
       if (self.isMobile == false){
@@ -678,8 +696,9 @@ H5P.BranchedVideo = (function ($) {
       // slanted slider listener, onclick itll jump to that branch
       var slantedBar = document.getElementById('tapestry-slanted-bar-' + slug);
       if (slantedBar){
-        slantedBar.onclick = function(){
+        slantedBar.childNodes[0].onclick = function(){
           if (currentVideoPlaying != slug){
+            slantedBar.childNodes[0].style.zIndex = 0;
             slantedBar.classList.remove('tapestry-slanted-bar');
             slantedBar.classList.add('tapestry-played-slanted-bar');
             video.currentTime = 0;
@@ -778,6 +797,14 @@ H5P.BranchedVideo = (function ($) {
           var mainSlider = currentBranch.getSliderDivHTML();
           mainSlider.classList.add('tapestry-selected-slider');
           mainSlider.childNodes[0].value = 0;
+          // CHANGED
+          // removes play button for main video on ended
+          currentBranch.getVideoHTML().onended = function(){
+            var playButton = document.getElementsByClassName('tapestry-play-button')[0];
+            playButton.style.display = 'block';
+            var pauseButton = document.getElementsByClassName('tapestry-pause-button')[0];
+            pauseButton.style.display = 'none';
+          }
         }
       }
 
@@ -1197,7 +1224,7 @@ H5P.BranchedVideo = (function ($) {
       // HELP EVENTS: on mouseover
       // HELP play button
       playButton.onmouseover = function(){
-        var temp = getHelpText('tapestry-help-play-button', 'click to play video' );
+        var temp = getHelpText('tapestry-help-play-button', 'CLICK TO PLAY VIDEO' );
         temp.style.left = '2%';
         temp.style.top = '60%';
         if (self.helpMode){
@@ -1205,12 +1232,12 @@ H5P.BranchedVideo = (function ($) {
         }
       }
       playButton.onmouseout = function(){
-        getHelpText('tapestry-help-play-button', 'click to play video').style.display = 'none';
+        getHelpText('tapestry-help-play-button', 'CLICK TO PLAY VIDEO').style.display = 'none';
       }
 
       // HELP pause button
       pauseButton.onmouseover = function(){
-        var temp = getHelpText('tapestry-help-pause-button', 'click to pause video' );
+        var temp = getHelpText('tapestry-help-pause-button', 'CLICK TO PAUSE VIDEO' );
         temp.style.left = '2%';
         temp.style.top = '60%';
         if (self.helpMode){
@@ -1218,12 +1245,12 @@ H5P.BranchedVideo = (function ($) {
         }
       }
       pauseButton.onmouseout = function(){
-        getHelpText('tapestry-help-pause-button', 'click to pause video').style.display = 'none';
+        getHelpText('tapestry-help-pause-button', 'CLICK TO PAUSE VIDEO').style.display = 'none';
       }
 
       // HELP volume button
       volumeButton.onmouseover = function(){
-        var temp = getHelpText('tapestry-help-volume-button', 'drag to change volume' );
+        var temp = getHelpText('tapestry-help-volume-button', 'DRAG TO CHANGE VOLUME' );
         temp.style.left = '83%';
         temp.style.top = '60%';
         if (self.helpMode){
@@ -1236,7 +1263,7 @@ H5P.BranchedVideo = (function ($) {
 
       // HELP fullscreen
       fullScreenButton.onmouseover = function(){
-        var temp = getHelpText('tapestry-help-fullScreen-button', 'toggle fullscreen' );
+        var temp = getHelpText('tapestry-help-fullScreen-button', 'TOGGLE FULL SCREEN' );
         temp.style.left = '87%';
         temp.style.top = '60%';
         if (self.helpMode){
@@ -1259,7 +1286,7 @@ H5P.BranchedVideo = (function ($) {
           if (self.isMobile){
             return;
           }
-          var temp = getHelpText('tapestry-help-'+ slug + '-slider', 'click to jump to ' + slug );
+          var temp = getHelpText('tapestry-help-'+ slug + '-slider', 'CLICK TO JUMP TO ' + slug );
           var dom = $container.get(0);
           var rect = dom.getBoundingClientRect();
           var currBranch = getBranch(currentVideoPlaying);
@@ -1304,7 +1331,7 @@ H5P.BranchedVideo = (function ($) {
             time = '0:00';
           }
           if (self.helpMode){
-            var temp = getHelpText('tapestry-help-'+ slug + '-slider', 'click to jump to ' + slug + ' at ' + time );
+            var temp = getHelpText('tapestry-help-'+ slug + '-slider', 'CLICK TO JUMP TO ' + slug + ' at ' + time );
           } else {
             var temp = getHelpText('tapestry-help-'+ slug + '-slider',  time );
           }

--- a/H5P.BranchedVideo/library.json
+++ b/H5P.BranchedVideo/library.json
@@ -3,7 +3,7 @@
   "description": "Creates a module of Branched Videos",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 877,
+  "patchVersion": 892,
   "runnable": 1,
   "author": "Amendor AS",
   "license": "cc-by-sa",

--- a/H5P.BranchedVideo/library.json
+++ b/H5P.BranchedVideo/library.json
@@ -3,7 +3,7 @@
   "description": "Creates a module of Branched Videos",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 852,
+  "patchVersion": 877,
   "runnable": 1,
   "author": "Amendor AS",
   "license": "cc-by-sa",


### PR DESCRIPTION
Made UI tweaks for the following:
- Please increase the size of the the video time texts by a couple of points.
- Please add a space before and after the slash in the video time texts. Also move the text 3 or 4 pixels more to the right.
- The volume slider thumb currently looks un-centered in Chrome. Please fix.
- The slanted bars should have a solid background not a background-image in the CSS. This renders much better and looks smoother.
- Please capitalize all help text
- Clicking on the slanted bar is a bit off. If I click on it close to its parent thread, it will seek to the parent thread instead of starting the video in the child thread with the slanted bar. Please adjust.
- Currently, when the video reaches its end, the play button does not change. If the video ended, the button should change to the play button.
- Clicking on the video itself should behave the same as pressing the play/pause button (i.e. if the video is playing, it should pause it and if it's paused, it should play it. If at the end of the video, it should play from the beginning).
- In the speed menu, please add a checkmark next to the selected speed to make it consistent with the settings menu.
- Please update CSS as follows for the settings / speed menu:
- Also for the settings menu, please do not set the 'left' position dynamically. I think it works fine if you leave it as default with the new CSS.